### PR TITLE
Refactor displayAmount function to include precision option

### DIFF
--- a/__tests__/utils/formatBalance.test.ts
+++ b/__tests__/utils/formatBalance.test.ts
@@ -85,9 +85,7 @@ describe("formatBalance tests", () => {
       },
     ];
     params.forEach((p) => {
-      expect(formatBalance(p.amount, p.decimals, { short: false })).toBe(
-        p.expected
-      );
+      expect(formatBalance(p.amount, p.decimals)).toBe(p.expected);
     });
   });
   it("should format balance with options", () => {
@@ -202,6 +200,41 @@ describe("formatBalance tests", () => {
           short: true,
         },
         expected: "1,000.00T TOKEN",
+      },
+      {
+        amount: "0.00000000001",
+        decimals: 0,
+        options: {
+          symbol: "TOKEN",
+          commify: true,
+          precision: 2,
+          short: true,
+        },
+        expected: "<0.001 TOKEN",
+      },
+      {
+        amount: "0.00000000001",
+        decimals: 0,
+        options: {
+          symbol: "TOKEN",
+          commify: true,
+          precision: 2,
+          short: true,
+          maxSmallBalance: 0.002,
+        },
+        expected: "<0.002 TOKEN",
+      },
+      {
+        amount: "1",
+        decimals: 18,
+        options: {
+          symbol: "TOKEN",
+          commify: true,
+          precision: 2,
+          short: true,
+          maxSmallBalance: 0.001,
+        },
+        expected: "<0.001 TOKEN",
       },
     ];
     params.forEach((p) => {

--- a/app/bridge/bridging.tsx
+++ b/app/bridge/bridging.tsx
@@ -2,7 +2,7 @@
 import Spacer from "@/components/layout/spacer";
 import Selector from "@/components/selector/selector";
 import Text from "@/components/text";
-import { displayAmount, formatBalance } from "@/utils/formatting";
+import { displayAmount } from "@/utils/formatting";
 import styles from "./bridge.module.scss";
 import Button from "@/components/button/button";
 import Input from "@/components/input/input";
@@ -48,13 +48,12 @@ const Bridging = ({ props }: { props: BridgeComboReturn }) => {
         fromNetwork={networkName(fromNetwork)}
         toNetwork={networkName(toNetwork)}
         type={bridge.direction}
-        amount={formatBalance(
+        amount={displayAmount(
           Amount.amountAsBigNumberString,
           token?.decimals ?? 0,
           {
             symbol: token?.symbol,
             precision: token?.decimals,
-            commify: true,
           }
         )}
         confirmation={{

--- a/app/lending/components/modal/modal.tsx
+++ b/app/lending/components/modal/modal.tsx
@@ -8,11 +8,7 @@ import styles from "./modal.module.scss";
 import Tabs from "@/components/tabs/tabs";
 import Image from "next/image";
 import Container from "@/components/container/container";
-import {
-  convertToBigNumber,
-  displayAmount,
-  formatBalance,
-} from "@/utils/formatting";
+import { convertToBigNumber, displayAmount } from "@/utils/formatting";
 import Icon from "@/components/icon/icon";
 import Spacer from "@/components/layout/spacer";
 import React, { useState } from "react";
@@ -89,9 +85,7 @@ export const LendingModal = (props: Props) => {
         )}
         <ModalItem
           name="Account Liquidity Remaining"
-          value={formatBalance(liquidityLeft, 18, {
-            commify: true,
-          })}
+          value={displayAmount(liquidityLeft, 18)}
           note
         />
       </Container>
@@ -159,7 +153,7 @@ export const LendingModal = (props: Props) => {
                 }}
               >
                 <Text font="proto_mono" size="sm">
-                  {formatBalance(cToken.collateralFactor, 16) + "%"}{" "}
+                  {displayAmount(cToken.collateralFactor, 16) + "%"}
                 </Text>
               </Container>
             }
@@ -428,8 +422,7 @@ const CTokenAmountCard = ({
         {name}
       </Text>
       <Text size="sm" font="proto_mono">
-        {formatBalance(amount, decimals, {
-          commify: true,
+        {displayAmount(amount, decimals, {
           symbol: note ? undefined : symbol,
         })}
         {valueInNote ? ` (${displayAmount(valueInNote.toString(), 18)} ` : " "}

--- a/app/lp/components/dexModals/stakeLPModal.tsx
+++ b/app/lp/components/dexModals/stakeLPModal.tsx
@@ -5,11 +5,7 @@ import { CTokenWithUserData } from "@/hooks/lending/interfaces/tokens";
 import styles from "./stakeModal.module.scss";
 import Image from "next/image";
 import Container from "@/components/container/container";
-import {
-  convertToBigNumber,
-  displayAmount,
-  formatBalance,
-} from "@/utils/formatting";
+import { convertToBigNumber, displayAmount } from "@/utils/formatting";
 import Icon from "@/components/icon/icon";
 import Spacer from "@/components/layout/spacer";
 import { useState } from "react";
@@ -236,8 +232,7 @@ const CTokenAmountCard = ({
         {name}
       </Text>
       <Text size="sm" font="proto_mono">
-        {formatBalance(amount, decimals, {
-          commify: true,
+        {displayAmount(amount, decimals, {
           symbol: note ? undefined : symbol,
         })}
         {valueInNote ? ` (${displayAmount(valueInNote.toString(), 18)} ` : " "}

--- a/app/lp/components/pairRow.tsx
+++ b/app/lp/components/pairRow.tsx
@@ -291,7 +291,9 @@ export const UserAmbientPairRow = ({
       {formatPercent(divideBalances(value, pool.totals.noteTvl))}
     </Text>,
     <Text key={pool.symbol + "value"}>
-      {displayAmount(value, 18)}
+      {displayAmount(value, 18, {
+        precision: 2,
+      })}
       <Icon
         style={{ marginLeft: "5px" }}
         themed
@@ -301,6 +303,7 @@ export const UserAmbientPairRow = ({
         }}
       />
     </Text>,
+
     <Text key={pool.symbol + "rewards"}>
       {displayAmount(rewards ?? "0", 18)}
     </Text>,

--- a/components/input/input.tsx
+++ b/components/input/input.tsx
@@ -3,7 +3,7 @@ import styles from "./input.module.scss";
 import Text from "../text";
 import clsx from "clsx";
 import Button from "../button/button";
-import { formatBalance } from "@/utils/formatting";
+import { displayAmount, formatBalance } from "@/utils/formatting";
 
 // if amount is true then add more required props
 type InputProps = {
@@ -72,10 +72,7 @@ const Input = (props: InputProps) => {
           {props.label}
           {props.type === "amount" && (
             <span className={styles["balance"]}>
-              Balance:{" "}
-              {formatBalance(props.balance, props.decimals, {
-                commify: true,
-              })}
+              Balance: {displayAmount(props.balance, props.decimals)}
             </span>
           )}
         </Text>

--- a/utils/formatting/balances.utils.ts
+++ b/utils/formatting/balances.utils.ts
@@ -37,12 +37,14 @@ export function convertToBigNumber(
  * @param {number} precision number of decimals to display
  * @param {boolean} commify whether to commify the balance
  * @param {boolean} short whether to display a short balance
+ * @param {number} maxSmallBalance the max balance to display before shortening (<maxSmallBalance)
  */
 interface FormatBalanceOptions {
   symbol?: string;
   precision?: number;
   commify?: boolean;
   short?: boolean;
+  maxSmallBalance?: number;
 }
 
 /**
@@ -61,6 +63,7 @@ export function displayAmount(
     precision: undefined,
     commify: true,
     short: true,
+    maxSmallBalance: undefined,
   };
   return formatBalance(amount, decimals, { ...defaultOptions, ...options });
 }
@@ -83,15 +86,13 @@ export function formatBalance(
     precision = undefined,
     commify = false,
     short = false,
+    maxSmallBalance = 0.001,
   } = options || {};
   const bnAmount = new BigNumber(amount);
   // make sure greater than zero
   if (bnAmount.isLessThanOrEqualTo(0)) return "0";
   // divide by 10^decimals
   const formattedAmount = bnAmount.dividedBy(new BigNumber(10).pow(decimals));
-
-  //   if the amount is less than 0.001, then return <.001
-  if (formattedAmount.isLessThan(0.001)) return "<.001";
 
   // if precision is undefined, ret2 places after the first non-zero decimal
   let truncateAt =
@@ -120,9 +121,15 @@ export function formatBalance(
   let finalAmount = truncatedAmount;
   let suffix = "";
   if (short) {
-    const { shortAmount, suffix: _suffix } = formatBigBalance(truncatedAmount);
-    finalAmount = shortAmount;
-    suffix = _suffix;
+    // check if the balance is less than 0.001 and return <0.001
+    if (Number(truncatedAmount) < maxSmallBalance) {
+      finalAmount = `<${maxSmallBalance}`;
+    } else {
+      const { shortAmount, suffix: _suffix } =
+        formatBigBalance(truncatedAmount);
+      finalAmount = shortAmount;
+      suffix = _suffix;
+    }
   }
 
   return `${

--- a/utils/formatting/balances.utils.ts
+++ b/utils/formatting/balances.utils.ts
@@ -89,11 +89,15 @@ export function formatBalance(
   if (bnAmount.isLessThanOrEqualTo(0)) return "0";
   // divide by 10^decimals
   const formattedAmount = bnAmount.dividedBy(new BigNumber(10).pow(decimals));
+
+  //   if the amount is less than 0.001, then return <.001
+  if (formattedAmount.isLessThan(0.001)) return "<.001";
+
   // if precision is undefined, ret2 places after the first non-zero decimal
   let truncateAt =
     precision ??
     2 - Math.floor(Math.log(formattedAmount.toNumber()) / Math.log(10));
-  // make sure tuncation is not negative or greater than decimals
+  // make sure truncation is not negative or greater than decimals
   truncateAt = Math.max(
     0,
     Math.min(truncateAt, decimals < 0 ? truncateAt : decimals)


### PR DESCRIPTION
This pull request refactors the displayAmount function to include a precision option. The precision option allows for more control over the decimal places displayed in the formatted amount. Additionally, the function now returns "<.001" if the amount is less than 0.001. This improves the readability and accuracy of the displayed amounts.