### PR TITLE
Fix confirmation modal

### DIFF
--- a/components/transactions/TxModal.tsx
+++ b/components/transactions/TxModal.tsx
@@ -38,6 +38,10 @@ const TransactionModal = () => {
         if (flow.status === "POPULATING") {
           setIsOpen(true);
           setCurrentFlowId(flow.id);
+          // close bridge/lp/lm confirmation modals
+          if (flow?.onSuccessCallback) {
+            flow.onSuccessCallback();
+          }
           return;
         }
       });


### PR DESCRIPTION
Close the transaction confirmation modal once the activity is generated and added to the store