### PR TITLE
analytics : Add network type to tx analytics

### DIFF
--- a/provider/analytics.tsx
+++ b/provider/analytics.tsx
@@ -88,6 +88,7 @@ export type AnalyticsTransactionFlowInfo = {
 
 type AnalyticsTransactionFlowParams = AnalyticsTransactionFlowInfo & {
   txType?: AnalyticsTransactionType;
+  txNetwork?: string;
   txSuccess?: boolean;
   txsGenerateError?: string;
   txError?: string;

--- a/stores/transactionStore.tsx
+++ b/stores/transactionStore.tsx
@@ -233,6 +233,7 @@ const useTransactionStore = create<TransactionStore>()(
                 i,
                 updatedTransactionList[i]
               );
+              const network = getNetworkInfoFromChainId(updatedTransactionList[i].tx.chainId).data
               // check if error (set states before throwing error)
               if (txError || !txResult) {
                 // perform tx will set the state of the tx and flow to error on it's own
@@ -241,6 +242,7 @@ const useTransactionStore = create<TransactionStore>()(
                   Analytics.actions.events.transactionFlows.transaction({
                     ...flowToPerform.analyticsTransactionFlowInfo,
                     txType: updatedTransactionList[i].tx.feTxType,
+                    txNetwork: network.isTestChain ? network.name : network.name + "Mainnet",
                     txSuccess: false,
                     txError: txError?.message.split(":").pop() ?? "",
                   });
@@ -252,6 +254,7 @@ const useTransactionStore = create<TransactionStore>()(
                 Analytics.actions.events.transactionFlows.transaction({
                   ...flowToPerform.analyticsTransactionFlowInfo,
                   txType: updatedTransactionList[i].tx.feTxType,
+                  txNetwork: network.isTestChain ? network.name : network.name + "Mainnet",
                   txSuccess: true,
                 });
               }


### PR DESCRIPTION
Add a network property to tx’s analytics data to be able to differentiate between canto testnet vs canto mainnet vs ethereum tx’s.