### PR TITLE
analytics : Add expected token amount analytics for remove liquidity txs

### DIFF
--- a/app/lp/components/ambient/managePosition.tsx
+++ b/app/lp/components/ambient/managePosition.tsx
@@ -418,9 +418,13 @@ const RemoveLiquidity = ({
         disabled={validParams.error}
         width={"fill"}
         onClick={() =>
-          sendTxFlow(
-            positionManager.createRemoveConcentratedLiquidtyParams(userParams)
-          )
+          sendTxFlow({
+            ...positionManager.createRemoveConcentratedLiquidtyParams(
+              userParams
+            ),
+            expectedBaseAmount: expectedTokens.base,
+            expectedQuoteAmount: expectedTokens.quote,
+          })
         }
       >
         {validParams.error ? validParams.reason : "Remove Liquidity"}

--- a/app/lp/components/ambient/newAmbientPosition.tsx
+++ b/app/lp/components/ambient/newAmbientPosition.tsx
@@ -370,7 +370,12 @@ export const NewAmbientPositionModal = ({
       <Button
         disabled={positionValidation.error}
         width={"fill"}
-        onClick={() => sendTxFlow(positionManager.txParams.addLiquidity())}
+        onClick={() =>
+          sendTxFlow({
+            ...positionManager.txParams.addLiquidity(),
+            isAdvanced: showAdvanced,
+          })
+        }
       >
         {positionValidation.error
           ? positionValidation.reason

--- a/app/lp/components/dexModals/RemoveLiquidityModal.tsx
+++ b/app/lp/components/dexModals/RemoveLiquidityModal.tsx
@@ -23,6 +23,8 @@ interface RemoveTxParams {
   amountLP: string;
   slippage: number;
   deadline: string;
+  expectedAmount1: string;
+  expectedAmount2: string;
 }
 export const createRemoveParams = (params: RemoveTxParams) => ({
   pair: params.pair,
@@ -31,6 +33,8 @@ export const createRemoveParams = (params: RemoveTxParams) => ({
   txType: CantoDexTxTypes.REMOVE_LIQUIDITY,
   amountLP: params.amountLP,
   unstake: true,
+  expectedAmount1: params.expectedAmount1,
+  expectedAmount2: params.expectedAmount2,
 });
 interface RemoveLiquidityProps {
   pair: CantoDexPairWithUserCTokenData;
@@ -51,6 +55,13 @@ export const RemoveLiquidityModal = ({
     pair.clmData?.userDetails?.supplyBalanceInUnderlying ?? "0",
     pair.clmData?.userDetails?.balanceOfUnderlying ?? "0"
   );
+
+  // expected tokens
+  const [expectedTokens, setExpectedTokens] = useState({
+    expectedToken1: "0",
+    expectedToken2: "0",
+  });
+
   // validation
   const paramCheck = validateParams({
     pair,
@@ -59,13 +70,10 @@ export const RemoveLiquidityModal = ({
     ).toString(),
     deadline,
     slippage,
+    expectedAmount1: expectedTokens.expectedToken1,
+    expectedAmount2: expectedTokens.expectedToken2,
   });
 
-  // expected tokens
-  const [expectedTokens, setExpectedTokens] = useState({
-    expectedToken1: "0",
-    expectedToken2: "0",
-  });
   useEffect(() => {
     async function getQuote() {
       const { data, error } = await quoteRemoveLiquidity(
@@ -229,6 +237,8 @@ export const RemoveLiquidityModal = ({
               ).toString(),
               deadline,
               slippage,
+              expectedAmount1: expectedTokens.expectedToken1,
+              expectedAmount2: expectedTokens.expectedToken2,
             })
           }
         >

--- a/provider/analytics.tsx
+++ b/provider/analytics.tsx
@@ -37,10 +37,10 @@ export type AnalyticsTransactionFlowData =
       cantoLpBalance2?: string;
       cantoLpTokenAmount?: string;
       cantoLpTokenBalance?: string;
-      cantoLpExpectedToken1?: string;
+      cantoLpExpectedAmount1?: string;
       cantoLpStakedBalance?: string;
       cantoLpUnstakedBalance?: string;
-      cantoLpExpectedToken2?: string;
+      cantoLpExpectedAmount2?: string;
       cantoLpSlippage?: Number;
       cantoLpDeadline?: string;
       cantoLpStakeStatus?: boolean;
@@ -61,7 +61,10 @@ export type AnalyticsTransactionFlowData =
       ambientLpMinExecPrice?: string;
       ambientLpMaxExecPrice?: string;
       ambientLpLiquidity?: string;
+      ambientLpExpectedBaseAmount?: string;
+      ambientLpExpectedQuoteAmount?: string;
       ambientLpFee?: string;
+      ambientLpIsAdvanced?: boolean;
     }
   | {
       // lending info

--- a/transactions/pairs/ambient/types.ts
+++ b/transactions/pairs/ambient/types.ts
@@ -24,12 +24,15 @@ export type AmbientAddConcentratedLiquidityParams = BaseConcLiqParams & {
   txType: AmbientTxType.ADD_CONC_LIQUIDITY;
   amount: string;
   isAmountBase: boolean;
+  isAdvanced?: boolean;
   positionId?: string;
 };
 export type AmbientRemoveConcentratedLiquidityParams = BaseConcLiqParams & {
   txType: AmbientTxType.REMOVE_CONC_LIQUIDITY;
   liquidity: string;
   positionId: string;
+  expectedBaseAmount?: string;
+  expectedQuoteAmount?: string;
 };
 
 export type AmbientClaimRewardsTxParams = {

--- a/utils/analytics/analytics.utils.ts
+++ b/utils/analytics/analytics.utils.ts
@@ -156,6 +156,7 @@ function getAmbientLiquidityTransactionFlowData(
     ];
     return {
       ...poolData,
+      ambientLpIsAdvanced: ambientLiquidityTxParams.isAdvanced ?? false,
       ambientLpBaseAmount: baseAmount,
       ambientLpQuoteAmount: quoteAmount,
       ambientLpBaseBalance: baseBalance,
@@ -163,9 +164,21 @@ function getAmbientLiquidityTransactionFlowData(
     };
   } else {
     // remove liquidity
+    const [ambientLpExpectedBaseAmount , ambientLpExpectedQuoteAmount] = [
+      displayAnalyticsAmount(
+        ambientLiquidityTxParams.expectedBaseAmount ?? "0",
+        ambientLiquidityTxParams.pool.base.decimals
+      ),
+      displayAnalyticsAmount(
+        ambientLiquidityTxParams.expectedQuoteAmount ?? "0",
+        ambientLiquidityTxParams.pool.quote.decimals
+      ),
+    ];
     return {
       ...poolData,
       ambientLpLiquidity: ambientLiquidityTxParams.liquidity,
+      ambientLpExpectedBaseAmount,
+      ambientLpExpectedQuoteAmount,
     };
   }
 }
@@ -220,11 +233,11 @@ function getCantoDexTransactionFlowData(
         ),
         cantoLpSlippage: cantoDexTxParams.slippage,
         cantoLpDeadline: cantoDexTxParams.deadline,
-        cantoLpExpectedToken1: displayAnalyticsAmount(
+        cantoLpExpectedAmount1: displayAnalyticsAmount(
           cantoDexTxParams.expectedAmount1 ?? "0",
           cantoDexTxParams.pair.token1.decimals
         ),
-        cantoLpExpectedToken2: displayAnalyticsAmount(
+        cantoLpExpectedAmount2: displayAnalyticsAmount(
           cantoDexTxParams.expectedAmount2 ?? "0",
           cantoDexTxParams.pair.token2.decimals
         ),


### PR DESCRIPTION
1 ) Add to tx flow analytics, the expected amount of tokens to be received when removing liquidity from canto dex  lps and ambient dex lp

2) Add "isAdvanced" property to ambient add_liquidity tx flow data for tracking this feature usage