### PR TITLE
Update borrow limit

### DIFF
--- a/app/lending/components/modal/modal.tsx
+++ b/app/lending/components/modal/modal.tsx
@@ -236,7 +236,15 @@ export const LendingModal = (props: Props) => {
           ? [90, 94, 98, 100]
           : null;
     const limitProps = limits
-      ? { limit: { limit: maxAmount, limitName: "Limit" } }
+      ? {
+          limit: {
+            limit:
+              actionType === CTokenLendingTxTypes.BORROW
+                ? percentOfAmount(maxAmount, 98.8).data
+                : maxAmount,
+            limitName: "Limit",
+          },
+        }
       : {};
 
     return (

--- a/components/amount/amount.tsx
+++ b/components/amount/amount.tsx
@@ -81,7 +81,14 @@ const Amount = (props: Props) => {
         props.symbol,
         props.decimals
       ),
-    [props.value, props.max, props.min, props.decimals, props.symbol]
+    [
+      props.value,
+      props.max,
+      props.min,
+      props.decimals,
+      props.symbol,
+      props.limit?.limit,
+    ]
   );
 
   return (

--- a/components/amount/amount.tsx
+++ b/components/amount/amount.tsx
@@ -77,7 +77,7 @@ const Amount = (props: Props) => {
       validateNonWeiUserInputTokenAmount(
         props.value,
         props.min,
-        props.max,
+        props.limit?.limit ?? props.max,
         props.symbol,
         props.decimals
       ),

--- a/transactions/lending/lending.ts
+++ b/transactions/lending/lending.ts
@@ -235,7 +235,7 @@ export function validateCTokenLendingTxParams(
   return validateWeiUserInputTokenAmount(
     txParams.amount,
     "1",
-    maxAmount,
+    txParams.txType ==  CTokenLendingTxTypes.BORROW ? percentOfAmount(maxAmount, 98.8).data : maxAmount,
     txParams.cToken.underlying.symbol,
     txParams.cToken.underlying.decimals
   );

--- a/transactions/lending/lending.ts
+++ b/transactions/lending/lending.ts
@@ -235,7 +235,9 @@ export function validateCTokenLendingTxParams(
   return validateWeiUserInputTokenAmount(
     txParams.amount,
     "1",
-    txParams.txType ==  CTokenLendingTxTypes.BORROW ? percentOfAmount(maxAmount, 98.8).data : maxAmount,
+    txParams.txType == CTokenLendingTxTypes.BORROW
+      ? percentOfAmount(maxAmount, 98.8).data
+      : maxAmount,
     txParams.cToken.underlying.symbol,
     txParams.cToken.underlying.decimals
   );


### PR DESCRIPTION
1) Update the limit shown to users in UI to 98.8% of their total borrow limit.
2) Add a validation to show error if user borrow more than 98.8% of their total borrow limit.