### PR TITLE
Fix spacing in tx modal

### DIFF
--- a/components/transactions/TxModal.tsx
+++ b/components/transactions/TxModal.tsx
@@ -156,11 +156,7 @@ const TransactionModal = () => {
                 transform: currentFlowId ? "translateX(0)" : "translateX(100%)",
               }}
             >
-              <div
-                style={{
-                  position: "absolute",
-                }}
-              >
+              <div>
                 <Container
                   direction="row"
                   gap={20}


### PR DESCRIPTION
When transactions are clicked in the transaction flow, fix the overflow of transactions on the back button.
