### PR TITLE
feat:mobile bridge page

### DIFF
--- a/app/bridge/bridging.tsx
+++ b/app/bridge/bridging.tsx
@@ -44,11 +44,8 @@ const Bridging = ({ props }: { props: BridgeComboReturn }) => {
 
   // special modal for gravity bridge out (check for wallet provider custom chains)
   const [gravityModalOpen, setGravityModalOpen] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
-  const screen = useScreenSize();
-  useEffect(() => {
-    setIsMobile(screen.width < 768);
-  }, [screen.width]);
+  const { isMobile } = useScreenSize();
+
   return (
     <>
       <GravityConfirmationModal

--- a/app/bridge/bridging.tsx
+++ b/app/bridge/bridging.tsx
@@ -20,6 +20,7 @@ import { useEffect, useState } from "react";
 import GravityConfirmationModal from "./components/gravityConfirmationModal";
 import { GRAVITY_BRIDGE } from "@/config/networks";
 import { TX_ERROR_TYPES } from "@/config/consts/errors";
+import useScreenSize from "@/hooks/helpers/useScreenSize";
 
 const Bridging = ({ props }: { props: BridgeComboReturn }) => {
   const {
@@ -43,7 +44,11 @@ const Bridging = ({ props }: { props: BridgeComboReturn }) => {
 
   // special modal for gravity bridge out (check for wallet provider custom chains)
   const [gravityModalOpen, setGravityModalOpen] = useState(false);
-
+  const [isMobile, setIsMobile] = useState(false);
+  const screen = useScreenSize();
+  useEffect(() => {
+    setIsMobile(screen.width < 768);
+  }, [screen.width]);
   return (
     <>
       <GravityConfirmationModal
@@ -235,7 +240,11 @@ const Bridging = ({ props }: { props: BridgeComboReturn }) => {
 
           <Container width="100%" gap={14}>
             <Text size="sm">Select Token and Enter Amount</Text>
-            <Container width="100%" direction="row" gap={20}>
+            <Container
+              width="100%"
+              direction={isMobile ? "column" : "row"}
+              gap={isMobile ? 50 : 20}
+            >
               <Selector
                 title="SELECT TOKEN"
                 activeItem={

--- a/app/bridge/bridging.tsx
+++ b/app/bridge/bridging.tsx
@@ -242,7 +242,7 @@ const Bridging = ({ props }: { props: BridgeComboReturn }) => {
             <Text size="sm">Select Token and Enter Amount</Text>
             <Container
               width="100%"
-              direction={isMobile ? "column" : "row"}
+              direction={!isMobile ? "row" : "column"}
               gap={isMobile ? 50 : 20}
             >
               <Selector

--- a/app/bridge/components/feeButton.tsx
+++ b/app/bridge/components/feeButton.tsx
@@ -49,7 +49,10 @@ const FeeButton = ({
         {subtext2}
       </Text>
       <div className={style.divider} />
-      <Text font="proto_mono">{`${tokenAmount} ${tokenSymbol}`}</Text>
+      <Text
+        font="proto_mono"
+        style={{ textAlign: "center" }}
+      >{`${tokenAmount} ${tokenSymbol}`}</Text>
       <Text size="x-sm" theme="secondary-dark">
         {"$" + tokenValueUSD}
       </Text>

--- a/app/bridge/components/gravityConfirmationModal.tsx
+++ b/app/bridge/components/gravityConfirmationModal.tsx
@@ -5,7 +5,8 @@ import Spacer from "@/components/layout/spacer";
 import Modal from "@/components/modal/modal";
 import Text from "@/components/text";
 import { GRAVITY_BRIGDE_EVM } from "@/config/networks";
-import { useState } from "react";
+import useScreenSize from "@/hooks/helpers/useScreenSize";
+import { useEffect, useState } from "react";
 
 interface Props {
   open: boolean;
@@ -20,6 +21,11 @@ const GravityConfirmationModal = ({
   onReselectMethod,
 }: Props) => {
   const [addChainError, setAddChainError] = useState<string | null>(null);
+  const [isMobile, setIsMobile] = useState(false);
+  const screen = useScreenSize();
+  useEffect(() => {
+    setIsMobile(screen.width < 768);
+  }, [screen.width]);
   async function handleConfirm() {
     try {
       // check that the user's wallet is actually supported
@@ -73,10 +79,13 @@ const GravityConfirmationModal = ({
       </Text>
       <Spacer height="30px" />
       <Container gap={20} direction="row" center={{ horizontal: true }}>
-        <Button onClick={handleConfirm}>
+        <Button onClick={handleConfirm} height={isMobile ? "large" : undefined}>
           {"I'm using a supported wallet"}
         </Button>{" "}
-        <Button onClick={onReselectMethod}>
+        <Button
+          onClick={onReselectMethod}
+          height={isMobile ? "large" : undefined}
+        >
           {"Use Gravity Bridge Portal"}
         </Button>
       </Container>

--- a/app/bridge/components/gravityConfirmationModal.tsx
+++ b/app/bridge/components/gravityConfirmationModal.tsx
@@ -6,7 +6,7 @@ import Modal from "@/components/modal/modal";
 import Text from "@/components/text";
 import { GRAVITY_BRIGDE_EVM } from "@/config/networks";
 import useScreenSize from "@/hooks/helpers/useScreenSize";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 interface Props {
   open: boolean;
@@ -21,11 +21,8 @@ const GravityConfirmationModal = ({
   onReselectMethod,
 }: Props) => {
   const [addChainError, setAddChainError] = useState<string | null>(null);
-  const [isMobile, setIsMobile] = useState(false);
-  const screen = useScreenSize();
-  useEffect(() => {
-    setIsMobile(screen.width < 768);
-  }, [screen.width]);
+  const { isMobile } = useScreenSize();
+
   async function handleConfirm() {
     try {
       // check that the user's wallet is actually supported

--- a/app/bridge/page.tsx
+++ b/app/bridge/page.tsx
@@ -7,18 +7,13 @@ import useBridgeCombo from "./util";
 import BridgeInProgress from "./components/bridgeInProgress";
 import styles from "./bridge.module.scss";
 import useBridgingInProgess from "@/hooks/bridge/useBridgingInProgress";
-import { useEffect, useState } from "react";
 import useScreenSize from "@/hooks/helpers/useScreenSize";
 
 export default function BridgePage() {
   const bridgeCombo = useBridgeCombo();
   const { Direction } = bridgeCombo;
   const bridgeProgress = useBridgingInProgess();
-  const [isMobile, setIsMobile] = useState(false);
-  const screen = useScreenSize();
-  useEffect(() => {
-    setIsMobile(screen.width < 768);
-  }, [screen.width]);
+  const { isMobile } = useScreenSize();
 
   return (
     <>

--- a/app/bridge/page.tsx
+++ b/app/bridge/page.tsx
@@ -7,7 +7,8 @@ import useBridgeCombo from "./util";
 import BridgeInProgress from "./components/bridgeInProgress";
 import styles from "./bridge.module.scss";
 import useBridgingInProgess from "@/hooks/bridge/useBridgingInProgress";
-import DesktopOnly from "@/components/desktop-only/desktop-only";
+import { useEffect, useState } from "react";
+import useScreenSize from "@/hooks/helpers/useScreenSize";
 
 export default function BridgePage() {
   const bridgeCombo = useBridgeCombo();
@@ -15,9 +16,15 @@ export default function BridgePage() {
   const bridgeProgress = useBridgingInProgess();
 
   //   if mobile only
-  if (!window.matchMedia("(min-width: 768px)").matches) {
-    return <DesktopOnly />;
-  }
+  // if (!window.matchMedia("(min-width: 768px)").matches) {
+  //   return <DesktopOnly />;
+  // }
+  const [isMobile, setIsMobile] = useState(false);
+  const screen = useScreenSize();
+  useEffect(() => {
+    setIsMobile(screen.width < 768);
+  }, [screen.width]);
+
   return (
     <>
       <AnimatedBackground
@@ -33,7 +40,7 @@ export default function BridgePage() {
         }}
       >
         <Container
-          width="700px"
+          width={isMobile ? "100vw" : "700px"}
           backgroundColor="var(--card-sub-surface-color, #DFDFDF)"
         >
           <Tabs
@@ -66,8 +73,10 @@ export default function BridgePage() {
                     setTxBridgeStatus={bridgeProgress.setTxBridgeStatus}
                   />
                 ),
+                hideOnMobile: true,
               },
             ]}
+            isMobile={isMobile}
           />
         </Container>
       </Container>

--- a/app/bridge/page.tsx
+++ b/app/bridge/page.tsx
@@ -14,11 +14,6 @@ export default function BridgePage() {
   const bridgeCombo = useBridgeCombo();
   const { Direction } = bridgeCombo;
   const bridgeProgress = useBridgingInProgess();
-
-  //   if mobile only
-  // if (!window.matchMedia("(min-width: 768px)").matches) {
-  //   return <DesktopOnly />;
-  // }
   const [isMobile, setIsMobile] = useState(false);
   const screen = useScreenSize();
   useEffect(() => {
@@ -76,7 +71,6 @@ export default function BridgePage() {
                 hideOnMobile: true,
               },
             ]}
-            isMobile={isMobile}
           />
         </Container>
       </Container>

--- a/components/tabs/tabs.tsx
+++ b/components/tabs/tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import styles from "./tabs.module.scss";
 import Text from "../text";
 import clsx from "clsx";
@@ -21,11 +21,8 @@ interface Props {
 }
 const Tabs = (props: Props) => {
   const [activeTab, setActiveTab] = useState(props.defaultIndex ?? 0);
-  const [isMobile, setIsMobile] = useState(false);
-  const screen = useScreenSize();
-  useEffect(() => {
-    setIsMobile(screen.width < 768);
-  }, [screen.width]);
+  const { isMobile } = useScreenSize();
+
   return (
     <div
       className={styles.container}

--- a/components/tabs/tabs.tsx
+++ b/components/tabs/tabs.tsx
@@ -13,12 +13,15 @@ interface Props {
     isDisabled?: boolean;
     onClick?: () => void;
     content: React.ReactNode;
+    hideOnMobile?: boolean;
   }[];
   height?: string;
   shadows?: boolean;
+  isMobile: boolean;
 }
 const Tabs = (props: Props) => {
   const [activeTab, setActiveTab] = useState(props.defaultIndex ?? 0);
+  const isMobile = props.isMobile;
   return (
     <div
       className={styles.container}
@@ -37,6 +40,7 @@ const Tabs = (props: Props) => {
             }}
             disabled={tab.isDisabled}
             className={clsx(styles.tab, activeTab === index && styles.active)}
+            style={isMobile && tab.hideOnMobile ? { display: "none" } : {}}
           >
             <Text font="proto_mono" size="sm" theme={"primary-dark"}>
               {tab.title}

--- a/components/tabs/tabs.tsx
+++ b/components/tabs/tabs.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import styles from "./tabs.module.scss";
 import Text from "../text";
 import clsx from "clsx";
+import useScreenSize from "@/hooks/helpers/useScreenSize";
 
 interface Props {
   defaultIndex?: number;
@@ -17,11 +18,14 @@ interface Props {
   }[];
   height?: string;
   shadows?: boolean;
-  isMobile: boolean;
 }
 const Tabs = (props: Props) => {
   const [activeTab, setActiveTab] = useState(props.defaultIndex ?? 0);
-  const isMobile = props.isMobile;
+  const [isMobile, setIsMobile] = useState(false);
+  const screen = useScreenSize();
+  useEffect(() => {
+    setIsMobile(screen.width < 768);
+  }, [screen.width]);
   return (
     <div
       className={styles.container}


### PR DESCRIPTION
- Removed the inprogress tab for bridge page mobile layout
- Made the bridge content responsive for mobile
<img width="511" alt="image" src="https://github.com/Plex-Engineer/canto-v3/assets/83865119/e32f9e3c-cc0a-4698-8f5b-65ea3794293c">
<img width="511" alt="image" src="https://github.com/Plex-Engineer/canto-v3/assets/83865119/d34ffe7e-71a2-4f8d-b096-defe87c8fdd4">
