### PR TITLE
hotfix: fix shifted rows in pools page

### DIFF
--- a/components/table/table.tsx
+++ b/components/table/table.tsx
@@ -37,7 +37,7 @@ const Table = (props: Props) => {
       <div
         className={styles.table}
         style={
-          !props.removeHeader
+          !isMobile && !props.removeHeader
             ? {
                 gridTemplateRows: "50px 1fr",
               }


### PR DESCRIPTION
Before -
![image](https://github.com/Plex-Engineer/canto-v3/assets/83865119/045d2314-7a05-4120-8196-bb182f5f1146)
After- 
![image](https://github.com/Plex-Engineer/canto-v3/assets/83865119/d57d46f7-1ab4-48d5-ac00-f5da751d27b4)
