### PR TITLE
patch: improvements for Staking Mobile layouts

### DIFF
--- a/app/staking/components/tableRows.tsx
+++ b/app/staking/components/tableRows.tsx
@@ -240,9 +240,7 @@ export const GenerateUnbondingDelegationsTableRow = (
   <Container
     key={`name_${index}`}
     width={isMobile ? "100%" : ""}
-    center={{ vertical: true }}
     style={{
-      justifyContent: isMobile ? "left" : "center",
       alignItems: isMobile ? "left" : "center",
       paddingLeft: "16px",
     }}

--- a/app/staking/components/tableRows.tsx
+++ b/app/staking/components/tableRows.tsx
@@ -38,6 +38,7 @@ export const GenerateValidatorTableRow = (
           overflow: "hidden",
           textOverflow: "ellipsis",
           whiteSpace: "nowrap",
+          textAlign: "left",
         }}
       >
         {validator.description.moniker}

--- a/app/staking/components/tableRows.tsx
+++ b/app/staking/components/tableRows.tsx
@@ -26,7 +26,6 @@ export const GenerateValidatorTableRow = (
     key={`name_${index}`}
     width={isMobile ? "100%" : ""}
     style={{
-      maxWidth: !isMobile ? "300px" : "150px",
       textAlign: isMobile ? "left" : "center",
       paddingLeft: isMobile ? "16px" : "",
     }}
@@ -38,7 +37,7 @@ export const GenerateValidatorTableRow = (
           overflow: "hidden",
           textOverflow: "ellipsis",
           whiteSpace: "nowrap",
-          textAlign: "left",
+          maxWidth: !isMobile ? "300px" : "140px",
         }}
       >
         {validator.description.moniker}
@@ -48,10 +47,13 @@ export const GenerateValidatorTableRow = (
   <Container
     key={`tokens_${index}`}
     direction="row"
-    center={{ horizontal: true, vertical: true }}
+    center={{ vertical: true }}
+    width={isMobile ? "100%" : ""}
     //gap="auto"
   >
-    <Text font="rm_mono">{displayAmount(validator.tokens, 18)} </Text>
+    <Text font="rm_mono" style={{ textAlign: isMobile ? "left" : "center" }}>
+      {displayAmount(validator.tokens, 18)}{" "}
+    </Text>
     <div> </div>
     <Icon
       style={{ marginLeft: "5px" }}
@@ -62,8 +64,8 @@ export const GenerateValidatorTableRow = (
       themed={true}
     />
   </Container>,
-  <Container key={`commission_${index}`}>
-    <Text font="rm_mono">
+  <Container key={`commission_${index}`} width={isMobile ? "100%" : ""}>
+    <Text font="rm_mono" style={{ textAlign: isMobile ? "left" : "center" }}>
       {displayAmount(validator.commission, -2, { precision: 2 })}%
     </Text>
   </Container>,
@@ -90,18 +92,38 @@ export const GenerateMyStakingTableRow = (
   onDelegate: (validator: Validator) => void,
   isMobile: boolean
 ) => [
-  <Container key={`name_${index}`}>
-    <Text font="rm_mono">{userStakedValidator?.description.moniker}</Text>
+  <Container
+    key={`name_${index}`}
+    width={isMobile ? "100%" : ""}
+    style={{
+      textAlign: isMobile ? "left" : "center",
+      paddingLeft: isMobile ? "16px" : "",
+    }}
+  >
+    <Text
+      font="rm_mono"
+      style={{
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+        maxWidth: !isMobile ? "300px" : "140px",
+      }}
+    >
+      {userStakedValidator?.description.moniker}
+    </Text>
   </Container>,
   <Container
     key={`mystake_${index}`}
     direction="row"
-    center={{ horizontal: true, vertical: true }}
+    width={isMobile ? "100%" : ""}
+    center={{ vertical: true }}
     gap="auto"
+    style={{ justifyContent: isMobile ? "left" : "center" }}
   >
-    <Text font="rm_mono">
+    <Text font="rm_mono" style={{ textAlign: isMobile ? "left" : "center" }}>
       {displayAmount(userStakedValidator.userDelegation.balance, 18, {
         short: false,
+        precision: 1,
       })}{" "}
     </Text>
     <div> </div>
@@ -118,7 +140,7 @@ export const GenerateMyStakingTableRow = (
     <Container
       key={`tokens_${index}`}
       direction="row"
-      center={{ horizontal: true, vertical: true }}
+      center={{ vertical: true }}
       gap="auto"
     >
       <Text font="rm_mono">
@@ -135,8 +157,13 @@ export const GenerateMyStakingTableRow = (
       />
     </Container>
   ),
-  <Container key={`commission_${index}`}>
-    <Text font="rm_mono">
+  <Container
+    key={`commission_${index}`}
+    width={isMobile ? "100%" : ""}
+    center={{ vertical: true }}
+    style={{ alignItems: isMobile ? "left" : "center" }}
+  >
+    <Text font="rm_mono" style={{ textAlign: isMobile ? "left" : "center" }}>
       {displayAmount(userStakedValidator?.commission, -2, {
         precision: 2,
       })}
@@ -167,14 +194,33 @@ export const GenerateUnbondingDelegationsTableRow = (
   index: number,
   isMobile?: boolean
 ) => [
-  <Container key={`name_${index}`}>
-    <Text font="rm_mono">{userStakedValidator.name}</Text>
+  <Container
+    key={`name_${index}`}
+    width={isMobile ? "100%" : ""}
+    style={{
+      textAlign: isMobile ? "left" : "center",
+      paddingLeft: isMobile ? "16px" : "",
+    }}
+  >
+    <Text
+      font="rm_mono"
+      style={{
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        whiteSpace: "nowrap",
+        maxWidth: !isMobile ? "300px" : "130px",
+      }}
+    >
+      {userStakedValidator.name}
+    </Text>
   </Container>,
   <Container
     key={`mystake_${index}`}
     direction="row"
-    center={{ horizontal: true, vertical: true }}
     gap="auto"
+    width={isMobile ? "100%" : ""}
+    center={{ vertical: true }}
+    style={{ justifyContent: isMobile ? "left" : "center" }}
   >
     <Text font="rm_mono">
       {displayAmount(userStakedValidator.undelegation, 18, {
@@ -191,8 +237,17 @@ export const GenerateUnbondingDelegationsTableRow = (
       themed={true}
     />
   </Container>,
-  <Container key={`name_${index}`}>
-    <Text font="rm_mono">
+  <Container
+    key={`name_${index}`}
+    width={isMobile ? "100%" : ""}
+    center={{ vertical: true }}
+    style={{
+      justifyContent: isMobile ? "left" : "center",
+      alignItems: isMobile ? "left" : "center",
+      paddingLeft: "16px",
+    }}
+  >
+    <Text font="rm_mono" style={{ textAlign: "left" }}>
       {!isMobile
         ? new Date(userStakedValidator.completion_date).toDateString() +
           ", " +

--- a/app/staking/page.tsx
+++ b/app/staking/page.tsx
@@ -283,20 +283,61 @@ export default function StakingPage() {
         <Container gap={20} width="100%">
           {userStaking && userStaking.unbonding.length > 0 && (
             <Table
-              title="Unbonding Delegations"
+              title={
+                <Container
+                  style={{ padding: isMobile ? "0px 0px 8px 8px" : "0" }}
+                >
+                  UNBONDING DELEGATIONS
+                </Container>
+              }
               headerFont="rm_mono"
               headers={[
                 {
-                  value: "Name",
+                  value: !isMobile ? (
+                    "Name"
+                  ) : (
+                    <Container
+                      width="100%"
+                      style={{
+                        textAlign: "left",
+                        paddingLeft: "16px",
+                      }}
+                    >
+                      Name
+                    </Container>
+                  ),
+                  ratio: 5,
+                },
+                {
+                  value: !isMobile ? (
+                    "Undelegation"
+                  ) : (
+                    <Container
+                      width="100%"
+                      style={{
+                        textAlign: "left",
+                      }}
+                    >
+                      Undelegation
+                    </Container>
+                  ),
                   ratio: 3,
                 },
                 {
-                  value: "Undelegation",
-                  ratio: 2,
-                },
-                {
-                  value: "Completion Time",
-                  ratio: 5,
+                  value: !isMobile ? (
+                    "Completion Time"
+                  ) : (
+                    <Container
+                      width="100%"
+                      style={{
+                        textAlign: "left",
+                        paddingLeft: "16px",
+                      }}
+                    >
+                      Completion
+                    </Container>
+                  ),
+                  ratio: 4,
                 },
               ]}
               content={[
@@ -312,7 +353,13 @@ export default function StakingPage() {
           )}
           {hasUserStaked && userStaking && (
             <Table
-              title="My Staking"
+              title={
+                <Container
+                  style={{ padding: isMobile ? "0px 0px 8px 8px" : "0" }}
+                >
+                  MY STAKING
+                </Container>
+              }
               headerFont="rm_mono"
               onRowsClick={
                 isMobile
@@ -332,11 +379,34 @@ export default function StakingPage() {
               }
               headers={[
                 {
-                  value: "Name",
+                  value: !isMobile ? (
+                    "Name"
+                  ) : (
+                    <Container
+                      width="100%"
+                      style={{
+                        textAlign: "left",
+                        paddingLeft: "16px",
+                      }}
+                    >
+                      Name
+                    </Container>
+                  ),
                   ratio: 5,
                 },
                 {
-                  value: "My Stake",
+                  value: !isMobile ? (
+                    "My Stake"
+                  ) : (
+                    <Container
+                      width="100%"
+                      style={{
+                        textAlign: "left",
+                      }}
+                    >
+                      My Stake
+                    </Container>
+                  ),
                   ratio: 3,
                 },
                 {
@@ -345,7 +415,18 @@ export default function StakingPage() {
                   hideOnMobile: true,
                 },
                 {
-                  value: "Commission",
+                  value: !isMobile ? (
+                    "Commission"
+                  ) : (
+                    <Container
+                      width="100%"
+                      style={{
+                        textAlign: "left",
+                      }}
+                    >
+                      Commission
+                    </Container>
+                  ),
                   ratio: 3,
                 },
                 {
@@ -377,20 +458,6 @@ export default function StakingPage() {
               ]}
             />
           )}
-          {/* {isMobile && (
-            <Container width={isMobile ? "100%" : "200px"}>
-              <ToggleGroup
-                options={["ACTIVE", "INACTIVE"]}
-                selected={currentFilter}
-                setSelected={(value) => {
-                  Analytics.actions.events.staking.tabSwitched(value);
-                  setCurrentFilter(value);
-                  setCurrentPage(1);
-                  setSearchQuery("");
-                }}
-              />
-            </Container>
-          )} */}
           {validators.length > 0 && (
             <Table
               title={
@@ -420,7 +487,9 @@ export default function StakingPage() {
                     flexDirection: isMobile ? "column-reverse" : "row",
                   }}
                 >
-                  <Container style={{ padding: isMobile ? "0 8px 0 8px" : "" }}>
+                  <Container
+                    style={{ padding: isMobile ? "0 8px 8px 8px" : "" }}
+                  >
                     <Input
                       height={38}
                       type="search"
@@ -462,7 +531,7 @@ export default function StakingPage() {
                       width="100%"
                       style={{
                         textAlign: "left",
-                        paddingLeft: "20px",
+                        paddingLeft: "16px",
                       }}
                     >
                       Name
@@ -471,11 +540,33 @@ export default function StakingPage() {
                   ratio: isMobile ? 5 : 6,
                 },
                 {
-                  value: "Total Stake",
+                  value: !isMobile ? (
+                    "Total Stake"
+                  ) : (
+                    <Container
+                      width="100%"
+                      style={{
+                        textAlign: "left",
+                      }}
+                    >
+                      Total Stake
+                    </Container>
+                  ),
                   ratio: 4,
                 },
                 {
-                  value: "Commission",
+                  value: !isMobile ? (
+                    "Commission"
+                  ) : (
+                    <Container
+                      width="100%"
+                      style={{
+                        textAlign: "left",
+                      }}
+                    >
+                      Commission
+                    </Container>
+                  ),
                   ratio: 3,
                 },
                 {

--- a/app/staking/page.tsx
+++ b/app/staking/page.tsx
@@ -395,7 +395,7 @@ export default function StakingPage() {
             <Table
               title={
                 <Container
-                  style={{ padding: isMobile ? "0px 0px 12px 8px" : "0" }}
+                  style={{ padding: isMobile ? "0px 0px 8px 8px" : "0" }}
                 >
                   VALIDATORS
                 </Container>
@@ -420,9 +420,7 @@ export default function StakingPage() {
                     flexDirection: isMobile ? "column-reverse" : "row",
                   }}
                 >
-                  <Container
-                    style={{ padding: isMobile ? "0 16px 0 16px" : "" }}
-                  >
+                  <Container style={{ padding: isMobile ? "0 8px 0 8px" : "" }}>
                     <Input
                       height={38}
                       type="search"
@@ -434,7 +432,7 @@ export default function StakingPage() {
 
                   <Container
                     width={isMobile ? "100%" : "200px"}
-                    style={{ padding: isMobile ? "0 16px 0 16px" : "" }}
+                    style={{ padding: isMobile ? "0 8px 0 8px" : "" }}
                   >
                     <ToggleGroup
                       options={["ACTIVE", "INACTIVE"]}


### PR DESCRIPTION
Staking Mobile Tables Earlier:
<img width="506" alt="Screenshot 2024-03-04 at 6 11 22 PM" src="https://github.com/Plex-Engineer/canto-v3/assets/66792600/13d12e12-4f3f-48d3-a346-117df0d43db7">
<img width="506" alt="Screenshot 2024-03-04 at 6 11 29 PM" src="https://github.com/Plex-Engineer/canto-v3/assets/66792600/9c7db6c8-704d-4edb-8249-8d701dc4a045">

After the changes: (majorly left aligned for columns on mobile)
<img width="506" alt="Screenshot 2024-03-04 at 6 11 49 PM" src="https://github.com/Plex-Engineer/canto-v3/assets/66792600/8c0edb3a-c841-43eb-b791-9a4a8b01c8e7">
<img width="506" alt="Screenshot 2024-03-04 at 6 11 58 PM" src="https://github.com/Plex-Engineer/canto-v3/assets/66792600/03c66606-f3b7-474c-9749-9f4c7fc704b6">


